### PR TITLE
Run 50 sequential fixes per schedule

### DIFF
--- a/.github/workflows/auto-fix-sequential.yml
+++ b/.github/workflows/auto-fix-sequential.yml
@@ -67,10 +67,10 @@ jobs:
               run: |
                   python ai_orchestrator.py queue-init
 
-            - name: Fix one article from queue
-              working-directory: Agent - Pinterest -Shopify Blog Autopilot - End-to-End Content Factory/pipeline_v2
-              run: |
-                  python ai_orchestrator.py queue-step
+                        - name: Fix up to 50 articles sequentially
+                            working-directory: Agent - Pinterest -Shopify Blog Autopilot - End-to-End Content Factory/pipeline_v2
+                            run: |
+                                    python ai_orchestrator.py queue-run 50 --delay=30 --no-subprocess
 
             - name: Upload fix artifacts
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
Update auto-fix workflow to process up to 50 articles sequentially per 6-hour run (no batch parallelism).