### PR TITLE
Skip queue init when no items

### DIFF
--- a/.github/workflows/auto-fix-manual.yml
+++ b/.github/workflows/auto-fix-manual.yml
@@ -124,7 +124,8 @@ jobs:
 
                   path = Path('articles_to_fix.json')
                   if not path.exists():
-                      raise SystemExit('articles_to_fix.json not found')
+                      print('articles_to_fix.json not found; skip rotate')
+                      raise SystemExit(0)
 
                   items = json.loads(path.read_text(encoding='utf-8'))
                   if not items:
@@ -142,6 +143,25 @@ jobs:
                             if: steps.queue_check.outputs.needs_refresh == 'true' && steps.fix_list.outputs.has_items == 'true'
               working-directory: Agent - Pinterest -Shopify Blog Autopilot - End-to-End Content Factory/pipeline_v2
               run: |
+                  python - <<'PY'
+                  import json
+                  from pathlib import Path
+
+                  path = Path('articles_to_fix.json')
+                  if not path.exists():
+                      print('articles_to_fix.json not found; skip queue init')
+                      raise SystemExit(0)
+
+                  try:
+                      items = json.loads(path.read_text(encoding='utf-8'))
+                  except json.JSONDecodeError:
+                      print('articles_to_fix.json invalid; skip queue init')
+                      raise SystemExit(0)
+
+                  if not items:
+                      print('No items to fix; skip queue init')
+                      raise SystemExit(0)
+                  PY
                   python ai_orchestrator.py queue-init
 
             - name: Fix up to 50 articles sequentially (no batch)

--- a/.github/workflows/auto-fix-sequential.yml
+++ b/.github/workflows/auto-fix-sequential.yml
@@ -127,7 +127,8 @@ jobs:
 
                   path = Path('articles_to_fix.json')
                   if not path.exists():
-                      raise SystemExit('articles_to_fix.json not found')
+                      print('articles_to_fix.json not found; skip rotate')
+                      raise SystemExit(0)
 
                   items = json.loads(path.read_text(encoding='utf-8'))
                   if not items:
@@ -145,6 +146,25 @@ jobs:
                             if: steps.queue_check.outputs.needs_refresh == 'true' && steps.fix_list.outputs.has_items == 'true'
               working-directory: Agent - Pinterest -Shopify Blog Autopilot - End-to-End Content Factory/pipeline_v2
               run: |
+                  python - <<'PY'
+                  import json
+                  from pathlib import Path
+
+                  path = Path('articles_to_fix.json')
+                  if not path.exists():
+                      print('articles_to_fix.json not found; skip queue init')
+                      raise SystemExit(0)
+
+                  try:
+                      items = json.loads(path.read_text(encoding='utf-8'))
+                  except json.JSONDecodeError:
+                      print('articles_to_fix.json invalid; skip queue init')
+                      raise SystemExit(0)
+
+                  if not items:
+                      print('No items to fix; skip queue init')
+                      raise SystemExit(0)
+                  PY
                   python ai_orchestrator.py queue-init
 
             - name: Fix up to 50 articles sequentially (no batch)


### PR DESCRIPTION
Guard rotate/queue-init steps so workflows skip cleanly when articles_to_fix.json is missing or empty.