### PR TITLE
Skip fix loop when queue missing

### DIFF
--- a/.github/workflows/auto-fix-manual.yml
+++ b/.github/workflows/auto-fix-manual.yml
@@ -157,6 +157,10 @@ jobs:
               working-directory: Agent - Pinterest -Shopify Blog Autopilot - End-to-End Content Factory/pipeline_v2
               run: |
                   set -euo pipefail
+                  if [ ! -f "anti_drift_queue.json" ]; then
+                      echo "No queue found; skipping fix loop."
+                      exit 0
+                  fi
                   max=${FIX_MAX_ITEMS:-50}
                   for i in $(seq 1 "$max"); do
                       article_id=$(python - <<'PY'

--- a/.github/workflows/auto-fix-sequential.yml
+++ b/.github/workflows/auto-fix-sequential.yml
@@ -160,6 +160,10 @@ jobs:
               working-directory: Agent - Pinterest -Shopify Blog Autopilot - End-to-End Content Factory/pipeline_v2
               run: |
                   set -euo pipefail
+                  if [ ! -f "anti_drift_queue.json" ]; then
+                      echo "No queue found; skipping fix loop."
+                      exit 0
+                  fi
                   max=${FIX_MAX_ITEMS:-50}
                   for i in $(seq 1 "$max"); do
                       article_id=$(python - <<'PY'


### PR DESCRIPTION
Prevent auto-fix workflows from failing when anti_drift_queue.json is absent.